### PR TITLE
feat/#15: NickNamePage 구현

### DIFF
--- a/src/components/NicknameInput.tsx
+++ b/src/components/NicknameInput.tsx
@@ -1,11 +1,23 @@
-import { useState } from "react";
+import { useState, useEffect } from 'react';
 
 interface NicknameInputProps {
+  value: string;
+  onChange: (value: string) => void;
   isExisting: boolean;
 }
 
-const NicknameInput = ({ isExisting }: NicknameInputProps) => {
-  const [nickname, setNickname] = useState("");
+const NicknameInput = ({ value, onChange, isExisting }: NicknameInputProps) => {
+  const [nickname, setNickname] = useState(value);
+
+  useEffect(() => {
+    setNickname(value);
+  }, [value]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    setNickname(newValue);
+    onChange(newValue);
+  };
 
   return (
     <div className="flex w-424 flex-col items-start gap-8">
@@ -17,7 +29,7 @@ const NicknameInput = ({ isExisting }: NicknameInputProps) => {
           <input
             value={nickname}
             maxLength={25}
-            onChange={(e) => setNickname(e.target.value)}
+            onChange={handleChange}
             className="text-title_body_20 text-sm self-stretch outline-0"
           />
         </div>

--- a/src/components/TextBox.tsx
+++ b/src/components/TextBox.tsx
@@ -7,7 +7,7 @@ const TextBox = () => {
 
   return (
     <div className="flex flex-col items-center gap-16 px-[259px] py-[69.5px] w-[1200px] rounded-[20px] border border-[#8B2FFF] bg-white">
-      <h2 className="text-[32px] font-medium text-center text-black">
+      <h2 className="text-[40px] font-semibold text-center text-black">
         {dummyData.title}
       </h2>
       <p className="text-[16px] font-medium text-center text-black whitespace-pre-line">

--- a/src/pages/NickNamePage.tsx
+++ b/src/pages/NickNamePage.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import EmojiCard from '@/components/EmojiCard';
+import TextBox from '@/components/TextBox';
+import NicknameInput from '@/components/NicknameInput';
+import GlobalButton from '@/components/GlobalButton';
+
+const NickNamePage = () => {
+  const [nickname, setNickname] = useState('');
+  const isValid = nickname.trim().length > 0;
+  //   const [isExisting, setIsExisting] = useState(false);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen gap-[64px] px-8 bg-white">
+      <TextBox />
+
+      <div className="flex gap-[120px] items-start">
+        <EmojiCard />
+
+        <div className="flex flex-col items-start gap-[24px] self-center">
+          <h1 className="text-center text-black font-semibold text-[40px] leading-normal font-['Noto Sans']">
+            닉네임을 입력해주세요!
+          </h1>
+          <NicknameInput
+            value={nickname}
+            onChange={setNickname}
+            isExisting={false}
+          />
+          <GlobalButton
+            text="입장하기"
+            isActive={isValid}
+            onClick={() => console.log('입장:', nickname)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NickNamePage;

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -1,11 +1,13 @@
-import LandingPage from "@/pages/LandingPage";
-import { Route, Routes } from "react-router-dom";
+import LandingPage from '@/pages/LandingPage';
+import NickNamePage from '@/pages/NickNamePage';
+import { Route, Routes } from 'react-router-dom';
 
 const AppRouter = () => {
   return (
     <>
       <Routes>
         <Route path="/" element={<LandingPage />} />
+        <Route path="/nickname" element={<NickNamePage />} />
       </Routes>
     </>
   );


### PR DESCRIPTION
## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#15 

<br><br>
## 📄 Work Description
- NicknameInput 컴포넌트에 value / onChange props 추가
- 부모 컴포넌트(NickNamePage.tsx)에서 전달한 nickname 값을 직접 제어할 수 있도록 변경
- useEffect로 내부 nickname 상태를 props와 동기화
- 외부에서 nickname 값이 바뀌면 내부에서도 자동 반영
- handleChange 함수에서 로컬 상태 setNickname() + 부모로 onChange() 같이 호출 → 상호 연동 가능
- 부모 컴포넌트에서는 nickname.trim().length > 0 조건으로 GlobalButton 활성화 제어


<br><br>
## 📷 Screenshot


<br><br>
## 💬 To Reviewers


<br><br>
## 🔗 Reference
